### PR TITLE
Add OAuth client credentials support

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const https = require('https');
+const { URLSearchParams } = require('url');
+
+/**
+ * Exchange OAuth client credentials for an access token
+ * @param {string} clientId - OAuth client ID
+ * @param {string} clientSecret - OAuth client secret
+ * @returns {Promise<string>} Access token
+ */
+function exchangeOAuthToken(clientId, clientSecret) {
+  return new Promise((resolve, reject) => {
+    const postData = new URLSearchParams({
+      grant_type: 'client_credentials',
+      client_id: clientId,
+      client_secret: clientSecret,
+    }).toString();
+
+    const options = {
+      hostname: 'api.tailscale.com',
+      port: 443,
+      path: '/api/v2/oauth/token',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Length': Buffer.byteLength(postData),
+      },
+    };
+
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        try {
+          const result = JSON.parse(data);
+          if (result.access_token) {
+            resolve(result.access_token);
+          } else {
+            reject(new Error(result.error_description || result.error || 'OAuth exchange failed'));
+          }
+        } catch (e) {
+          reject(new Error('Invalid OAuth response: ' + data));
+        }
+      });
+    });
+
+    req.on('error', reject);
+    req.write(postData);
+    req.end();
+  });
+}
+
+module.exports = { exchangeOAuthToken };


### PR DESCRIPTION
## Summary

This PR adds support for Tailscale OAuth client credentials as an alternative to auth keys.

## Problem

Auth keys expire after 90 days, requiring users to re-authenticate regularly. OAuth client credentials provide a longer-term solution.

## Changes

- **lib/oauth.js** — New module for OAuth token exchange with Tailscale API
- **lib/setup.js** — Updated to:
  - Detect and use existing OAuth credentials
  - Exchange OAuth credentials for access tokens
  - Fall back to auth key if OAuth fails
  - Pass OAuth flag to startup script
- **templates/start-tailscale.sh** — Updated to:
  - Check for  first (OAuth)
  - Fall back to  (legacy)
  - Provide clear error if neither is configured
- **README.md** — Added comprehensive OAuth documentation

## Usage

### Option 1: OAuth (Recommended)

1. Create an OAuth client at https://login.tailscale.com/admin/settings/trust-credentials
   - Select scope: 
   - Note the Client ID and Client Secret
2. Add credentials to Zo secrets:
   
[1;36m[1/5][0m [1mTailscale auth key[0m
  No TAILSCALE_AUTHKEY found in zo secrets.
  Generate one at: https://login.tailscale.com/admin/settings/keys
3. Run  — it will automatically use OAuth

### Option 2: Auth Key (Legacy)

Continue using auth keys as before:


## Backwards Compatibility

Auth keys continue to work exactly as before. OAuth is only used when  and  are present.

## Testing

To test this PR:
1. Create an OAuth client in your Tailscale admin panel
2. Set  and  in your Zo secrets
3. Run 
4. Verify Tailscale connects using OAuth

Fixes #1